### PR TITLE
fix: use ECR pull-through cache for Docker Hub base images

### DIFF
--- a/Dockerfile.rocker
+++ b/Dockerfile.rocker
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE_TAG
+ARG ROCKER_REGISTRY
 
-FROM node:22-alpine3.19
+FROM ${ROCKER_REGISTRY:+${ROCKER_REGISTRY}/}node:22-alpine3.19 AS node
 
 # Install necessary dependencies (curl and ca-certificates)
 RUN apk add --no-cache curl ca-certificates && \
@@ -8,7 +9,7 @@ RUN apk add --no-cache curl ca-certificates && \
     curl -fsSLk -o /usr/local/share/ca-certificates/nrel_xca1.crt https://raw.github.nrel.gov/TADA/nrel-certs/v20180329/certs/nrel_xca1.pem && \
     update-ca-certificates
 
-FROM rocker/r-ver:${BASE_IMAGE_TAG:-4.4.3}
+FROM ${ROCKER_REGISTRY:+${ROCKER_REGISTRY}/}rocker/r-ver:${BASE_IMAGE_TAG:-4.4.3}
 
 RUN mkdir /usr/src/app
 


### PR DESCRIPTION
When `ROCKER_REGISTRY` build arg is set (e.g. to an ECR pull-through cache prefix like `991404956194.dkr.ecr.us-west-2.amazonaws.com/docker-hub`), Docker Hub images are pulled via the ECR cache. This avoids Docker Hub rate limits and transient 502 errors that break CI builds.

When `ROCKER_REGISTRY` is unset (local dev), falls back to pulling directly from Docker Hub.

The CodeBuild project already passes `ROCKER_REGISTRY` as a build arg (configured in the doeseed-seedweb terraform).